### PR TITLE
Make map name and description editable in editor

### DIFF
--- a/NavigationOnly/Scenes/MapEditor.tscn
+++ b/NavigationOnly/Scenes/MapEditor.tscn
@@ -299,3 +299,4 @@ wrap_mode = 1
 [connection signal="text_changed" from="Editor/TabContainer/Items/ItemEditor/Scenery/MarginContainer/SceneryInput" to="Editor/TabContainer/Items/ItemEditor" method="_on_scenery_input_text_changed"]
 [connection signal="text_changed" from="Editor/TabContainer/Items/ItemEditor/Aliases/MarginContainer/AliasInput" to="Editor/TabContainer/Items/ItemEditor" method="_on_alias_input_text_changed"]
 [connection signal="timeout" from="Editor/TabContainer/Items/ItemEditor/Timer" to="Editor/TabContainer/Items/ItemEditor" method="_on_timer_timeout"]
+[connection signal="text_changed" from="Editor/TabContainer/Map/MarginContainer/VBoxContainer/HBoxContainer/MapNameInput" to="." method="_on_map_name_input_text_changed"]

--- a/NavigationOnly/Scenes/MapEditor.tscn
+++ b/NavigationOnly/Scenes/MapEditor.tscn
@@ -282,7 +282,8 @@ size_flags_vertical = 3
 layout_mode = 2
 text = "Map Description: "
 
-[node name="TextEdit" type="TextEdit" parent="Editor/TabContainer/Map/MarginContainer/VBoxContainer/VBoxContainer"]
+[node name="MapDescriptionInput" type="TextEdit" parent="Editor/TabContainer/Map/MarginContainer/VBoxContainer/VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 placeholder_text = "Description of your map."

--- a/NavigationOnly/Scenes/MapEditor.tscn
+++ b/NavigationOnly/Scenes/MapEditor.tscn
@@ -27,58 +27,64 @@ theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="VSplitContainer" type="VSplitContainer" parent="Editor"]
+[node name="TabContainer" type="TabContainer" parent="Editor"]
 layout_mode = 2
+current_tab = 1
 
-[node name="PanelContainer" type="PanelContainer" parent="Editor/VSplitContainer"]
+[node name="Items" type="VSplitContainer" parent="Editor/TabContainer"]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 0
+
+[node name="PanelContainer" type="PanelContainer" parent="Editor/TabContainer/Items"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Editor/VSplitContainer/PanelContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Editor/TabContainer/Items/PanelContainer"]
 layout_mode = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="Editor/VSplitContainer/PanelContainer/VBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="Editor/TabContainer/Items/PanelContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="Editor/VSplitContainer/PanelContainer/VBoxContainer/MarginContainer"]
+[node name="HBoxContainer2" type="HBoxContainer" parent="Editor/TabContainer/Items/PanelContainer/VBoxContainer/MarginContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Editor/VSplitContainer/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Editor/TabContainer/Items/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2"]
 visible = false
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Editor/VSplitContainer/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2/HBoxContainer"]
+[node name="Label" type="Label" parent="Editor/TabContainer/Items/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2/HBoxContainer"]
 layout_mode = 2
 text = "Map Name: "
 
-[node name="LineEdit" type="LineEdit" parent="Editor/VSplitContainer/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2/HBoxContainer"]
+[node name="LineEdit" type="LineEdit" parent="Editor/TabContainer/Items/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="Editor/VSplitContainer/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2"]
+[node name="HBoxContainer2" type="HBoxContainer" parent="Editor/TabContainer/Items/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Editor/VSplitContainer/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2/HBoxContainer2"]
+[node name="Label" type="Label" parent="Editor/TabContainer/Items/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2/HBoxContainer2"]
 layout_mode = 2
 text = "Starting Room: "
 
-[node name="StartingRoomInput" type="LineEdit" parent="Editor/VSplitContainer/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2/HBoxContainer2"]
+[node name="StartingRoomInput" type="LineEdit" parent="Editor/TabContainer/Items/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2/HBoxContainer2"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "Room Identifier"
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Editor/VSplitContainer/PanelContainer/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="Editor/TabContainer/Items/PanelContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 follow_focus = true
 
-[node name="MarginContainer" type="MarginContainer" parent="Editor/VSplitContainer/PanelContainer/VBoxContainer/ScrollContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="Editor/TabContainer/Items/PanelContainer/VBoxContainer/ScrollContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -87,30 +93,30 @@ theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="ItemMapEditor" type="CenterContainer" parent="Editor/VSplitContainer/PanelContainer/VBoxContainer/ScrollContainer/MarginContainer"]
+[node name="ItemMapEditor" type="CenterContainer" parent="Editor/TabContainer/Items/PanelContainer/VBoxContainer/ScrollContainer/MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 script = ExtResource("1_2j7kv")
 
-[node name="GridContainer" type="GridContainer" parent="Editor/VSplitContainer/PanelContainer/VBoxContainer/ScrollContainer/MarginContainer/ItemMapEditor"]
+[node name="GridContainer" type="GridContainer" parent="Editor/TabContainer/Items/PanelContainer/VBoxContainer/ScrollContainer/MarginContainer/ItemMapEditor"]
 layout_mode = 2
 theme_override_constants/h_separation = 5
 theme_override_constants/v_separation = 5
 columns = 30
 
-[node name="ItemEditor" type="TabContainer" parent="Editor/VSplitContainer"]
+[node name="ItemEditor" type="TabContainer" parent="Editor/TabContainer/Items"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 current_tab = 0
 script = ExtResource("3_e6a6i")
 
-[node name="Item" type="Panel" parent="Editor/VSplitContainer/ItemEditor"]
+[node name="Item" type="Panel" parent="Editor/TabContainer/Items/ItemEditor"]
 layout_mode = 2
 metadata/_tab_index = 0
 
-[node name="MarginContainer" type="MarginContainer" parent="Editor/VSplitContainer/ItemEditor/Item"]
+[node name="MarginContainer" type="MarginContainer" parent="Editor/TabContainer/Items/ItemEditor/Item"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -122,27 +128,27 @@ theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Editor/VSplitContainer/ItemEditor/Item/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer4" type="HBoxContainer" parent="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer"]
+[node name="HBoxContainer4" type="HBoxContainer" parent="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer4"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer4"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer4/HBoxContainer"]
+[node name="Label" type="Label" parent="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer4/HBoxContainer"]
 layout_mode = 2
 text = "Cell Color"
 
-[node name="MapCellColorInput" type="ColorPickerButton" parent="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer4/HBoxContainer"]
+[node name="MapCellColorInput" type="ColorPickerButton" parent="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer4/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Cell Color"
 color = Color(0.2, 0.2, 0.2, 1)
 edit_alpha = false
 
-[node name="DescriptionInput" type="TextEdit" parent="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer"]
+[node name="DescriptionInput" type="TextEdit" parent="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -152,102 +158,143 @@ wrap_mode = 1
 syntax_highlighter = SubResource("SyntaxHighlighter_ikksk")
 highlight_all_occurrences = true
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer"]
+[node name="HBoxContainer2" type="HBoxContainer" parent="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer2"]
+[node name="Label" type="Label" parent="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer2"]
 layout_mode = 2
 text = "Reference String"
 
-[node name="ReferenceStringInput" type="LineEdit" parent="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer2"]
+[node name="ReferenceStringInput" type="LineEdit" parent="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "example_reference_string"
 
-[node name="HBoxContainer3" type="HBoxContainer" parent="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer"]
+[node name="HBoxContainer3" type="HBoxContainer" parent="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer3"]
+[node name="Label" type="Label" parent="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer3"]
 layout_mode = 2
 text = "Display Name"
 
-[node name="DisplayNameInput" type="LineEdit" parent="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer3"]
+[node name="DisplayNameInput" type="LineEdit" parent="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer3"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "Example Display Name"
 
-[node name="Connections" type="PanelContainer" parent="Editor/VSplitContainer/ItemEditor"]
+[node name="Connections" type="PanelContainer" parent="Editor/TabContainer/Items/ItemEditor"]
 visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 metadata/_tab_index = 1
 
-[node name="MarginContainer" type="MarginContainer" parent="Editor/VSplitContainer/ItemEditor/Connections"]
+[node name="MarginContainer" type="MarginContainer" parent="Editor/TabContainer/Items/ItemEditor/Connections"]
 layout_mode = 2
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="ConnectionsInput" type="CodeEdit" parent="Editor/VSplitContainer/ItemEditor/Connections/MarginContainer"]
+[node name="ConnectionsInput" type="CodeEdit" parent="Editor/TabContainer/Items/ItemEditor/Connections/MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 placeholder_text = "EAST: example_room_reference_string
 SOUTH: example_room_reference_string
 CHARLOTTE: example_string_for_arbitrary_direction"
 
-[node name="Scenery" type="PanelContainer" parent="Editor/VSplitContainer/ItemEditor"]
+[node name="Scenery" type="PanelContainer" parent="Editor/TabContainer/Items/ItemEditor"]
 visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 metadata/_tab_index = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="Editor/VSplitContainer/ItemEditor/Scenery"]
+[node name="MarginContainer" type="MarginContainer" parent="Editor/TabContainer/Items/ItemEditor/Scenery"]
 layout_mode = 2
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="SceneryInput" type="CodeEdit" parent="Editor/VSplitContainer/ItemEditor/Scenery/MarginContainer"]
+[node name="SceneryInput" type="CodeEdit" parent="Editor/TabContainer/Items/ItemEditor/Scenery/MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 placeholder_text = "EAST: example_room_reference_string
 SOUTH: example_room_reference_string
 CHARLOTTE: example_string_for_arbitrary_direction"
 
-[node name="Aliases" type="PanelContainer" parent="Editor/VSplitContainer/ItemEditor"]
+[node name="Aliases" type="PanelContainer" parent="Editor/TabContainer/Items/ItemEditor"]
 visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 metadata/_tab_index = 3
 
-[node name="MarginContainer" type="MarginContainer" parent="Editor/VSplitContainer/ItemEditor/Aliases"]
+[node name="MarginContainer" type="MarginContainer" parent="Editor/TabContainer/Items/ItemEditor/Aliases"]
 layout_mode = 2
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="AliasInput" type="CodeEdit" parent="Editor/VSplitContainer/ItemEditor/Aliases/MarginContainer"]
+[node name="AliasInput" type="CodeEdit" parent="Editor/TabContainer/Items/ItemEditor/Aliases/MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 placeholder_text = "EAST: example_room_reference_string
 SOUTH: example_room_reference_string
 CHARLOTTE: example_string_for_arbitrary_direction"
 
-[node name="Timer" type="Timer" parent="Editor/VSplitContainer/ItemEditor"]
+[node name="Timer" type="Timer" parent="Editor/TabContainer/Items/ItemEditor"]
 wait_time = 5.0
 
-[connection signal="text_changed" from="Editor/VSplitContainer/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2/HBoxContainer2/StartingRoomInput" to="." method="_on_starting_room_input_text_changed"]
-[connection signal="item_selected" from="Editor/VSplitContainer/PanelContainer/VBoxContainer/ScrollContainer/MarginContainer/ItemMapEditor" to="." method="_on_center_container_item_selected"]
-[connection signal="color_changed" from="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer4/HBoxContainer/MapCellColorInput" to="Editor/VSplitContainer/ItemEditor" method="_on_map_cell_color_input_color_changed"]
-[connection signal="text_changed" from="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer/DescriptionInput" to="Editor/VSplitContainer/ItemEditor" method="_on_description_input_text_changed"]
-[connection signal="text_changed" from="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer2/ReferenceStringInput" to="Editor/VSplitContainer/ItemEditor" method="_on_reference_string_input_text_changed"]
-[connection signal="text_changed" from="Editor/VSplitContainer/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer3/DisplayNameInput" to="Editor/VSplitContainer/ItemEditor" method="_on_display_name_input_text_changed"]
-[connection signal="text_changed" from="Editor/VSplitContainer/ItemEditor/Connections/MarginContainer/ConnectionsInput" to="Editor/VSplitContainer/ItemEditor" method="_on_connections_input_text_changed"]
-[connection signal="text_changed" from="Editor/VSplitContainer/ItemEditor/Scenery/MarginContainer/SceneryInput" to="Editor/VSplitContainer/ItemEditor" method="_on_scenery_input_text_changed"]
-[connection signal="text_changed" from="Editor/VSplitContainer/ItemEditor/Aliases/MarginContainer/AliasInput" to="Editor/VSplitContainer/ItemEditor" method="_on_alias_input_text_changed"]
-[connection signal="timeout" from="Editor/VSplitContainer/ItemEditor/Timer" to="Editor/VSplitContainer/ItemEditor" method="_on_timer_timeout"]
+[node name="Map" type="PanelContainer" parent="Editor/TabContainer"]
+layout_mode = 2
+metadata/_tab_index = 1
+
+[node name="MarginContainer" type="MarginContainer" parent="Editor/TabContainer/Map"]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Editor/TabContainer/Map/MarginContainer"]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Editor/TabContainer/Map/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Editor/TabContainer/Map/MarginContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "Map Name: "
+
+[node name="MapNameInput" type="LineEdit" parent="Editor/TabContainer/Map/MarginContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+placeholder_text = "Name of your map, shown to players."
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Editor/TabContainer/Map/MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="Label" type="Label" parent="Editor/TabContainer/Map/MarginContainer/VBoxContainer/VBoxContainer"]
+layout_mode = 2
+text = "Map Description: "
+
+[node name="TextEdit" type="TextEdit" parent="Editor/TabContainer/Map/MarginContainer/VBoxContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+placeholder_text = "Description of your map."
+wrap_mode = 1
+
+[connection signal="text_changed" from="Editor/TabContainer/Items/PanelContainer/VBoxContainer/MarginContainer/HBoxContainer2/HBoxContainer2/StartingRoomInput" to="." method="_on_starting_room_input_text_changed"]
+[connection signal="item_selected" from="Editor/TabContainer/Items/PanelContainer/VBoxContainer/ScrollContainer/MarginContainer/ItemMapEditor" to="." method="_on_center_container_item_selected"]
+[connection signal="color_changed" from="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer4/HBoxContainer/MapCellColorInput" to="Editor/TabContainer/Items/ItemEditor" method="_on_map_cell_color_input_color_changed"]
+[connection signal="text_changed" from="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer/DescriptionInput" to="Editor/TabContainer/Items/ItemEditor" method="_on_description_input_text_changed"]
+[connection signal="text_changed" from="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer2/ReferenceStringInput" to="Editor/TabContainer/Items/ItemEditor" method="_on_reference_string_input_text_changed"]
+[connection signal="text_changed" from="Editor/TabContainer/Items/ItemEditor/Item/MarginContainer/VBoxContainer/HBoxContainer3/DisplayNameInput" to="Editor/TabContainer/Items/ItemEditor" method="_on_display_name_input_text_changed"]
+[connection signal="text_changed" from="Editor/TabContainer/Items/ItemEditor/Connections/MarginContainer/ConnectionsInput" to="Editor/TabContainer/Items/ItemEditor" method="_on_connections_input_text_changed"]
+[connection signal="text_changed" from="Editor/TabContainer/Items/ItemEditor/Scenery/MarginContainer/SceneryInput" to="Editor/TabContainer/Items/ItemEditor" method="_on_scenery_input_text_changed"]
+[connection signal="text_changed" from="Editor/TabContainer/Items/ItemEditor/Aliases/MarginContainer/AliasInput" to="Editor/TabContainer/Items/ItemEditor" method="_on_alias_input_text_changed"]
+[connection signal="timeout" from="Editor/TabContainer/Items/ItemEditor/Timer" to="Editor/TabContainer/Items/ItemEditor" method="_on_timer_timeout"]

--- a/NavigationOnly/Scripts/MapEditor.gd
+++ b/NavigationOnly/Scripts/MapEditor.gd
@@ -5,14 +5,24 @@ class_name MapEditor
 var itemEditor: ItemEditor = %ItemEditor
 @onready
 var itemMapEditor: ItemMapEditor = %ItemMapEditor
+
+# TODO split these out into... something
+# them being spread out between the two tabs is slightly annoying
+# but I don't want to add another script to the Editor node
+# too many things being piped around....
 @onready
 var startingRoomInput: LineEdit = %StartingRoomInput
+@onready
+var mapNameInput: LineEdit = %MapNameInput
+@onready
+var mapDescriptionInput: TextEdit = %MapDescriptionInput
 
 var _currentGame: EditorGame = EditorGame.NewEmptyGame()
 
 
 func getGame() -> EditorGame:
 	itemEditor.requestSave()
+	_save_big_text_to_map()
 	return _currentGame
 
 func setGame(game: EditorGame) -> void:
@@ -29,6 +39,9 @@ func _ready() -> void:
 func _item_selected(item: Item) -> void:
 	setItemEditorItem(item)
 
+func _save_big_text_to_map() -> void:
+	_currentGame.mapDescription = mapDescriptionInput.text
+
 func setItemEditorItem(item: Item) -> void:
 	itemEditor.item = item
 
@@ -37,10 +50,15 @@ func updateUiForCurrentGame() -> void:
 		return
 	itemMapEditor.setItems(_currentGame.placedItems)
 	startingRoomInput.text = _currentGame.startingRoomIdentifier
+	mapNameInput.text = _currentGame.mapName
+	mapDescriptionInput.text = _currentGame.mapDescription
 
 
 func updateStartingRoomIdentifier(newValue: String) -> void:
 	_currentGame.startingRoomIdentifier = newValue
+
+func updateMapName(newValue: String) -> void:
+	_currentGame.mapName = newValue
 
 
 func _on_center_container_item_selected(item: Item) -> void:
@@ -49,3 +67,17 @@ func _on_center_container_item_selected(item: Item) -> void:
 
 func _on_starting_room_input_text_changed(new_text: String) -> void:
 	updateStartingRoomIdentifier(new_text)
+
+
+func _on_map_name_input_text_changed(new_text: String) -> void:
+	updateMapName(new_text)
+
+# NOTE no map description signal in here because I just write it
+# to the EditorGame whenever the current game is requested
+# unlike the big text in the item description
+# where we have a timer and everything
+# if I were writing to a file periodically this would make sense
+# but now I'm just confused on why I did that at all?
+# probably because I hadn't considered that I would want to
+# save to mem whenever swapping items or playing the map or saving the game to disk
+# so it probably isn't needed at all. Whoops!

--- a/NavigationOnly/Scripts/Resources/EditorGame.gd
+++ b/NavigationOnly/Scripts/Resources/EditorGame.gd
@@ -6,9 +6,9 @@ class_name EditorGame
 @export
 var startingRoomIdentifier: String = ""
 @export
-var mapName: String = "Map"
+var mapName: String = ""
 @export
-var mapDescription: String = "Description"
+var mapDescription: String = ""
 # My kingdom for a typed dictionary.
 #@export
 #var gridSize: Vector2i = Vector2i(30, 30)


### PR DESCRIPTION
- Added tab container to editor with Map and Items tabs.
- Added map name and description input fields in editor.
- Update description value in current game whenever getting the current game.
	- Notes on updating the current game instance in the editor: Item editor updates large text items based on a timer, whenever the game is fetched, and whenever switching the item in the item editor component. Map description doesn't bother with the timer. Because I'm pretty sure writing to the editor game on a timeout is doing nothing for me. Should I ever write to the actual file on a timeout, then it might come into use, but at that point might as well move the timer up and push up a 'bigValueChanged' signal or the like.