### PR TITLE
Import and Export Maps for the Navigation-only Prototype

### DIFF
--- a/NavigationOnly/Scenes/CreateNewMapView.tscn
+++ b/NavigationOnly/Scenes/CreateNewMapView.tscn
@@ -1,0 +1,76 @@
+[gd_scene load_steps=2 format=3 uid="uid://e213f7bfvlgd"]
+
+[ext_resource type="Script" path="res://NavigationOnly/Scripts/MapList/NewMapView.gd" id="1_iog2n"]
+
+[node name="CreateNewMapView" type="MarginContainer"]
+offset_right = 40.0
+offset_bottom = 40.0
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+script = ExtResource("1_iog2n")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "File Name: "
+
+[node name="FileNameInput" type="LineEdit" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(150, 0)
+layout_mode = 2
+
+[node name="Label2" type="Label" parent="VBoxContainer/HBoxContainer"]
+self_modulate = Color(1, 1, 1, 0.686275)
+layout_mode = 2
+text = ".mn8a"
+
+[node name="CreateMapButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Create Map"
+
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="VBoxContainer/VBoxContainer"]
+layout_mode = 2
+text = "Import Map Data (Optional):"
+
+[node name="MapDataInput" type="TextEdit" parent="VBoxContainer/VBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 200)
+layout_mode = 2
+wrap_mode = 1
+
+[node name="ErrorContainer" type="PanelContainer" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/ErrorContainer"]
+custom_minimum_size = Vector2(0, 150)
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/ErrorContainer/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="ErrorLabel" type="RichTextLabel" parent="VBoxContainer/ErrorContainer/ScrollContainer/MarginContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+
+[connection signal="pressed" from="VBoxContainer/CreateMapButton" to="." method="_on_create_map_button_pressed"]

--- a/NavigationOnly/Scenes/MapBrowser.tscn
+++ b/NavigationOnly/Scenes/MapBrowser.tscn
@@ -148,6 +148,12 @@ layout_mode = 2
 size_flags_horizontal = 8
 text = "Open Map"
 
+[node name="ExportMapButton" type="Button" parent="MarginContainer/VBoxContainer/VSplitContainer/MapInfoContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 8
+text = "Export Map"
+
 [node name="FilenameLabel" type="Label" parent="MarginContainer/VBoxContainer/VSplitContainer/MapInfoContainer/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
@@ -181,8 +187,31 @@ initial_position = 2
 
 [node name="CreateNewMapView" parent="NewMapPopup" instance=ExtResource("4_e7hp1")]
 
+[node name="ExportPopup" type="Popup" parent="."]
+unique_name_in_owner = true
+size = Vector2i(320, 320)
+
+[node name="PanelContainer" type="PanelContainer" parent="ExportPopup"]
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="MarginContainer" type="MarginContainer" parent="ExportPopup/PanelContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="ExportContent" type="TextEdit" parent="ExportPopup/PanelContainer/MarginContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(300, 300)
+layout_mode = 2
+editable = false
+wrap_mode = 1
+
 [connection signal="game_selected" from="MarginContainer/VBoxContainer/VSplitContainer/MapListContainer/MarginContainer/ScrollContainer/MapList" to="." method="_on_map_list_game_selected"]
 [connection signal="open_map_clicked" from="MarginContainer/VBoxContainer/VSplitContainer/MapInfoContainer" to="." method="_on_map_info_container_open_map_clicked"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/VSplitContainer/MapInfoContainer/MarginContainer/VBoxContainer/HBoxContainer/OpenMapButton" to="MarginContainer/VBoxContainer/VSplitContainer/MapInfoContainer" method="_on_open_map_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/VSplitContainer/MapInfoContainer/MarginContainer/VBoxContainer/HBoxContainer/ExportMapButton" to="." method="_on_export_map_button_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/PanelContainer/MakeNewMapButton" to="." method="_on_make_new_map_button_pressed"]
 [connection signal="newMapRequested" from="NewMapPopup/CreateNewMapView" to="." method="_on_create_new_map_view_new_map_requested"]

--- a/NavigationOnly/Scenes/MapBrowser.tscn
+++ b/NavigationOnly/Scenes/MapBrowser.tscn
@@ -1,16 +1,19 @@
-[gd_scene load_steps=6 format=3 uid="uid://bd2ge0v8oe2sq"]
+[gd_scene load_steps=7 format=3 uid="uid://bd2ge0v8oe2sq"]
 
 [ext_resource type="Script" path="res://NavigationOnly/Scripts/MapList/MapListUpdater.gd" id="1_ee0qs"]
 [ext_resource type="Script" path="res://NavigationOnly/Scripts/MapList/MapBrowser.gd" id="1_iwvjo"]
 [ext_resource type="Script" path="res://NavigationOnly/Scripts/MapList/MapInfoView.gd" id="3_3r0py"]
+[ext_resource type="PackedScene" uid="uid://e213f7bfvlgd" path="res://NavigationOnly/Scenes/CreateNewMapView.tscn" id="4_e7hp1"]
 
 [sub_resource type="SystemFont" id="SystemFont_hnv7e"]
 font_names = PackedStringArray("Sans-Serif")
 font_weight = 700
+subpixel_positioning = 0
 
 [sub_resource type="SystemFont" id="SystemFont_b25du"]
 font_names = PackedStringArray("Sans-Serif")
 font_weight = 300
+subpixel_positioning = 0
 
 [node name="MapBrowser" type="Control"]
 layout_mode = 3
@@ -172,7 +175,14 @@ layout_mode = 2
 layout_mode = 2
 text = "New Map"
 
+[node name="NewMapPopup" type="Popup" parent="."]
+title = "New Map"
+initial_position = 2
+
+[node name="CreateNewMapView" parent="NewMapPopup" instance=ExtResource("4_e7hp1")]
+
 [connection signal="game_selected" from="MarginContainer/VBoxContainer/VSplitContainer/MapListContainer/MarginContainer/ScrollContainer/MapList" to="." method="_on_map_list_game_selected"]
 [connection signal="open_map_clicked" from="MarginContainer/VBoxContainer/VSplitContainer/MapInfoContainer" to="." method="_on_map_info_container_open_map_clicked"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/VSplitContainer/MapInfoContainer/MarginContainer/VBoxContainer/HBoxContainer/OpenMapButton" to="MarginContainer/VBoxContainer/VSplitContainer/MapInfoContainer" method="_on_open_map_button_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/PanelContainer/MakeNewMapButton" to="." method="_on_make_new_map_button_pressed"]
+[connection signal="newMapRequested" from="NewMapPopup/CreateNewMapView" to="." method="_on_create_new_map_view_new_map_requested"]

--- a/NavigationOnly/Scenes/NavigationOnlyApp.tscn
+++ b/NavigationOnly/Scenes/NavigationOnlyApp.tscn
@@ -12,7 +12,6 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_nqfgg")
-games = null
 
 [node name="MapBrowser" parent="." instance=ExtResource("2_hlsaf")]
 layout_mode = 1
@@ -21,6 +20,7 @@ layout_mode = 1
 visible = false
 layout_mode = 1
 
+[connection signal="creating_file" from="MapBrowser" to="." method="_on_map_browser_creating_file"]
 [connection signal="opening_map" from="MapBrowser" to="." method="_on_map_browser_opening_map"]
 [connection signal="exit_editor" from="EditAndPlayMaps" to="." method="_on_edit_and_play_maps_exit_editor"]
 [connection signal="save_game_to_disk" from="EditAndPlayMaps" to="." method="_on_edit_and_play_maps_save_game_to_disk"]

--- a/NavigationOnly/Scripts/AppStateController.gd
+++ b/NavigationOnly/Scripts/AppStateController.gd
@@ -51,9 +51,11 @@ func readAndOpenMap(mapListItemInfo: MapListItemInfo) -> void:
 	
 	var saveContext = SaveContext.new(mapListItemInfo.filename)
 	openMap(editorGame, saveContext)
-	
-	
-	
+
+
+func openMapWithFilenameForSaving(filename: String, editorGame: EditorGame) -> void:
+	var saveContext = SaveContext.new(filename)
+	openMap(editorGame, saveContext)
 
 func openMap(editorGame: EditorGame, saveContext: SaveContext) -> void:
 	toggleOffControl(mapBrowser)
@@ -87,12 +89,14 @@ func saveGameToDisk(editorGame: EditorGame, saveContext: SaveContext) -> void:
 func _on_map_browser_opening_map(mapListItemInfo: MapListItemInfo) -> void:
 	readAndOpenMap(mapListItemInfo)
 
+func _on_map_browser_creating_file(filename: String, editorGame: EditorGame) -> void:
+	openMapWithFilenameForSaving(filename, editorGame)
+
 func _on_edit_and_play_maps_save_game_to_disk(editorGame: EditorGame, saveContext: SaveContext) -> void:
 	saveGameToDisk(editorGame, saveContext)
 
 func _on_edit_and_play_maps_exit_editor() -> void:
 	backToBrowser()
-
 
 
 func toggleOffControl(control: Control) -> void:

--- a/NavigationOnly/Scripts/FileHandling/FileReader.gd
+++ b/NavigationOnly/Scripts/FileHandling/FileReader.gd
@@ -1,0 +1,14 @@
+extends RefCounted
+class_name FileReader
+
+@export
+var path: String
+
+# "where should the path not be stored" for 10 points!
+
+func _init(fullFilePath: String) -> void:
+	path = fullFilePath
+
+
+func read() -> String:
+	return FileAccess.get_file_as_string(path)

--- a/NavigationOnly/Scripts/FileHandling/MapFileLoader.gd
+++ b/NavigationOnly/Scripts/FileHandling/MapFileLoader.gd
@@ -9,4 +9,5 @@ func _init(filePath: String) -> void:
 
 func read() -> EditorGame:
 	var fileContent = FileAccess.get_file_as_string(fullFilePath)
-	return EditorGame._from_dict(JSON.parse_string(fileContent))
+	var parser = MapParser.new()
+	return parser.parse(fileContent)

--- a/NavigationOnly/Scripts/FileHandling/MapFileLoader.gd
+++ b/NavigationOnly/Scripts/FileHandling/MapFileLoader.gd
@@ -4,10 +4,16 @@ class_name MapFileLoader
 @export
 var fullFilePath: String
 
+# TODO: shove in the map parser and file reader into here.
+# The file reader should probably not actually hold onto the filename...
+# Mmmm...
+# ALSO TODO: make this take the map parser and file reader as init vars. DI it up.
+
 func _init(filePath: String) -> void:
 	fullFilePath = filePath
 
 func read() -> EditorGame:
-	var fileContent = FileAccess.get_file_as_string(fullFilePath)
+	var reader = FileReader.new(fullFilePath)
 	var parser = MapParser.new()
+	var fileContent = reader.read()
 	return parser.parse(fileContent)

--- a/NavigationOnly/Scripts/FileHandling/MapParser.gd
+++ b/NavigationOnly/Scripts/FileHandling/MapParser.gd
@@ -1,0 +1,14 @@
+extends RefCounted
+class_name MapParser
+
+@export
+var parser: Callable = func (_x): return EditorGame.NewEmptyGame()
+
+func _init(parserFunction: Callable = func (string: String) -> EditorGame:
+	return EditorGame._from_dict(JSON.parse_string(string))
+	) -> void:
+	
+	parser = parserFunction
+
+func parse(string: String) -> EditorGame:
+	return parser.call(string)

--- a/NavigationOnly/Scripts/MapList/MapBrowser.gd
+++ b/NavigationOnly/Scripts/MapList/MapBrowser.gd
@@ -2,6 +2,7 @@ extends Control
 class_name MapBrowser
 
 signal opening_map(mapListItemInfo: MapListItemInfo)
+signal creating_file(filename: String, editorGame: EditorGame)
 
 @export
 var games: Array[MapListItemInfo] = []:
@@ -18,6 +19,8 @@ var mapList: MapListUpdater = %MapList:
 	set(value):
 		mapList = value
 		updateUi()
+@onready
+var newMapPopup: Popup = $NewMapPopup
 
 var currentSelectedItem: MapListItemInfo:
 	set(value):
@@ -60,8 +63,22 @@ func updateSelectedMap(mapListItemInfo: MapListItemInfo) -> void:
 func openMap(item: MapListItemInfo) -> void:
 	opening_map.emit(item)
 
+func continueWithNewMap(filename: String, mapData: String) -> void:
+	var game: EditorGame
+	if mapData.is_empty():
+		game = EditorGame.NewEmptyGame()
+	else:
+		game = EditorGame._from_dict(JSON.parse_string(mapData))
+	creating_file.emit(filename, game)
+	newMapPopup.hide()
+
+func startNewMapFlow() -> void:
+	newMapPopup.always_on_top = true
+	newMapPopup.popup_centered()
+	newMapPopup.show()
+
 func _on_make_new_map_button_pressed() -> void:
-	openMap(MapListItemInfo.BrandNewFile())
+	startNewMapFlow()
 
 
 func _on_map_list_game_selected(mapListItemInfo: MapListItemInfo) -> void:
@@ -70,3 +87,7 @@ func _on_map_list_game_selected(mapListItemInfo: MapListItemInfo) -> void:
 
 func _on_map_info_container_open_map_clicked() -> void:
 	openMap(currentSelectedItem)
+
+
+func _on_create_new_map_view_new_map_requested(filename: String, mapData: String) -> void:
+	continueWithNewMap(filename, mapData)

--- a/NavigationOnly/Scripts/MapList/MapBrowser.gd
+++ b/NavigationOnly/Scripts/MapList/MapBrowser.gd
@@ -19,8 +19,13 @@ var mapList: MapListUpdater = %MapList:
 	set(value):
 		mapList = value
 		updateUi()
+
 @onready
 var newMapPopup: Popup = $NewMapPopup
+@onready
+var exportPopup: Popup = %ExportPopup
+@onready
+var exportContent: TextEdit = %ExportContent
 
 var currentSelectedItem: MapListItemInfo:
 	set(value):
@@ -49,13 +54,20 @@ func updateMapInfo() -> void:
 		mapInfoContainer.item = currentSelectedItem
 		return
 	
-	var reader := MapFileLoader.new("user://maps".path_join(currentSelectedItem.filename))
+	var reader := MapFileLoader.new(makePath(currentSelectedItem.filename))
 	var game := reader.read()
 	var mapItemCopy := currentSelectedItem.duplicate()
 	mapItemCopy.mapName = game.mapName
 	mapItemCopy.mapDescription = game.mapDescription
 	
 	mapInfoContainer.item = mapItemCopy
+
+func makePath(filename: String) -> String:
+	return "user://maps".path_join(currentSelectedItem.filename)
+
+func getFileContent(filepath: String) -> String:
+	var reader = FileReader.new(filepath)
+	return reader.read()
 
 func updateSelectedMap(mapListItemInfo: MapListItemInfo) -> void:
 	currentSelectedItem = mapListItemInfo
@@ -77,6 +89,12 @@ func startNewMapFlow() -> void:
 	newMapPopup.popup_centered()
 	newMapPopup.show()
 
+func openExportPopupForCurrentItem() -> void:
+	var content := getFileContent(makePath(currentSelectedItem.filename))
+	exportContent.text = content
+	exportPopup.popup_centered()
+	exportPopup.show()
+
 func _on_make_new_map_button_pressed() -> void:
 	startNewMapFlow()
 
@@ -91,3 +109,7 @@ func _on_map_info_container_open_map_clicked() -> void:
 
 func _on_create_new_map_view_new_map_requested(filename: String, mapData: String) -> void:
 	continueWithNewMap(filename, mapData)
+
+
+func _on_export_map_button_pressed() -> void:
+	openExportPopupForCurrentItem()

--- a/NavigationOnly/Scripts/MapList/MapInfoView.gd
+++ b/NavigationOnly/Scripts/MapList/MapInfoView.gd
@@ -17,9 +17,6 @@ var filenameLabel: Label = %FilenameLabel
 @onready
 var descriptionLabel: Label = %MapDescriptionLabel
 
-#@onready
-#var openMapButton: Button = %OpenMapButton
-
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	updateUi()

--- a/NavigationOnly/Scripts/MapList/NewMapView.gd
+++ b/NavigationOnly/Scripts/MapList/NewMapView.gd
@@ -1,0 +1,83 @@
+extends Node
+
+signal newMapRequested(filename: String, mapData: String)
+
+@onready
+var fileNameInput: LineEdit = %FileNameInput
+@onready
+var mapDataInput: TextEdit = %MapDataInput
+@onready
+var errorLabel: RichTextLabel = %ErrorLabel
+
+class NewMapError:
+	var message: String = ""
+	func _init(msg: String) -> void:
+		message = msg
+
+func _ready() -> void:
+	resetFields()
+
+func resetFields() -> void:
+	resetErrorLabel()
+	mapDataInput.text = ""
+	fileNameInput.text = ""
+
+func getFilename() -> String:
+	return fileNameInput.text + ".mn8a"
+func getMapData() -> String:
+	return mapDataInput.text.strip_edges()
+
+func showErrors(errors: Array[NewMapError]) -> void:
+	var errorText = joinErrors(errors)
+	errorLabel.text = errorText
+
+func joinErrors(errors: Array[NewMapError]) -> String:
+	var errorText: Array[String]
+	errorText.assign(
+		errors.map(func (error) -> String: return error.message)
+	)
+	return "\n".join(errorText)
+
+func resetErrorLabel() -> void:
+	errorLabel.text = ""
+
+func _validateInput(filename: String, mapContent: String) -> Array[NewMapError]:
+	var data = mapContent.strip_edges()
+	var errors: Array[NewMapError] = []
+	if not data.is_empty():
+		# just checking for valid json
+		# anything else and we just get a failure to open...
+		# not ideal!
+		# but also I don't want to wrap the parser return in a result...
+		var check = JSON.parse_string(mapContent)
+		if check == null:
+			errors.append(
+				NewMapError.new("Could not parse JSON map data.")
+			)
+	if not filename.validate_filename():
+		errors.append(
+			NewMapError.new("The file name is not valid.")
+		)
+	else:
+		var filepath = "user://maps".path_join(filename)
+		if FileAccess.file_exists(filepath):
+			errors.append(
+				NewMapError.new("File name already in use.")
+			)
+	return errors
+
+func tryCreateMap() -> void:
+	var filename = getFilename()
+	var mapData = getMapData()
+	var errors = _validateInput(filename, mapData)
+	if not errors.is_empty():
+		showErrors(errors)
+		return
+	else:
+		resetErrorLabel()
+	print("I am perfectly happy with this request to make a new map file.")
+	resetFields()
+	newMapRequested.emit(filename, mapData)
+
+func _on_create_map_button_pressed() -> void:
+	tryCreateMap()

--- a/NavigationOnly/Scripts/Resources/EditorGame.gd
+++ b/NavigationOnly/Scripts/Resources/EditorGame.gd
@@ -35,10 +35,10 @@ static func _to_dict(game: EditorGame) -> Dictionary:
 
 static func _from_dict(dictionary: Dictionary) -> EditorGame:
 	var newGame = EditorGame.NewEmptyGame()
-	newGame.startingRoomIdentifier = dictionary[STARTING_ROOM_KEY]
-	newGame.mapName = dictionary[MAP_NAME_KEY]
-	newGame.mapDescription = dictionary[MAP_DESCRIPTION_KEY]
-	var placedItems = PlacedItems._from_string_keyed_dict(dictionary[PLACED_ITEMS_KEY])
+	newGame.startingRoomIdentifier = dictionary.get(STARTING_ROOM_KEY, "")
+	newGame.mapName = dictionary.get(MAP_NAME_KEY, "")
+	newGame.mapDescription = dictionary.get(MAP_DESCRIPTION_KEY, "")
+	var placedItems = PlacedItems._from_string_keyed_dict(dictionary.get(PLACED_ITEMS_KEY, ""))
 	newGame.placedItems = placedItems
 	return newGame
 	


### PR DESCRIPTION
- Adds ability to specify a filename (but only when you first create the map file. Very nice UX)
- Adds ability to "import" and "export" maps with copy and paste.
- Adds export button in map browser which opens a popup showing the file content.
- File reading is a little more relaxed. Missing params in map data JSON (except for the placed items field) get default values now. Mostly empty strings.

Strange import + export here for getting file content out of browser DBs, but seeing as we're saving to `user://` on desktop as well, this is less hassle than bumbling down into appdata or the equivalent all around.
There's probably a nicer solution, but this technically works! _Really_ embracing developer UI with this one.